### PR TITLE
package import fixes + typing fix to submenu buttons

### DIFF
--- a/src/SlickCTk/slick_buttons.py
+++ b/src/SlickCTk/slick_buttons.py
@@ -2,11 +2,11 @@
 # pylint: disable=missing-module-docstring,
 
 from tkinter import Variable
-from typing import Callable, Tuple, Union, Optional
+from typing import Callable, Tuple, Union, Optional, Any
 from customtkinter import CTkButton
 from customtkinter.windows.widgets.font import CTkFont
 from customtkinter.windows.widgets.image import CTkImage
-from slick_settings import (
+from SlickCTk.slick_settings import (
     BUTTON_COLOR_TEXT,
     BUTTON_COLOR_BACKGROUND,
     BUTTON_COLOR_HOVER,
@@ -22,7 +22,7 @@ from slick_settings import (
 class SlickButton(CTkButton):
     def __init__(
         self,
-        master: any,
+        master: Any,
         width: int = 140,
         height: int = 28,
         corner_radius: Optional[int] = BUTTON_CORNER_RADIUS,

--- a/src/SlickCTk/slick_context_menu.py
+++ b/src/SlickCTk/slick_context_menu.py
@@ -27,12 +27,12 @@ TODO
 """
 
 import tkinter as tk
-from typing import Callable, Optional
-from customtkinter import CTkFrame, CTk, CTkBaseClass
-from slick_buttons import ContextMenuButton, SubmenuButton
-from utilities.dpi_scaler import DPIScaler
+from typing import Callable, Any
+from customtkinter import CTkFrame, CTk
+from SlickCTk.slick_buttons import ContextMenuButton, SubmenuButton
+from SlickCTk.utilities.dpi_scaler import DPIScaler
 
-from slick_settings import (
+from SlickCTk.slick_settings import (
     MENU_COLOR_BACKGROUND,
     MENU_COLOR_OUTLINE,
     MENU_PADDING_X,
@@ -56,7 +56,7 @@ class SlickContextMenu(CTkFrame):
             **kwargs,
         )
 
-        self.root = parent
+        self.root: Any = parent
         self.dpi_scaler = DPIScaler()
         self.len_menu_choices: int = len(menu_choices)
 
@@ -267,19 +267,20 @@ class _ContextMenuSubframe(CTkFrame):
 
         for button_text, button_content in menu_choices.items():
             if isinstance(button_content, Callable):
-                self.add_commmand(
-                    button_text, button_content
-                )
+                self.add_button(button_text, button_content)
 
             elif isinstance(button_content, dict):
-                button: SubmenuButton = self.add_commmand(button_text, None)
+                button: SubmenuButton = self.add_submenu_button(button_text)
                 self.add_submenu(button, button_content)
 
-    def add_commmand(
-        self, button_text: str, button_command: Callable | None
-    ) -> SubmenuButton:
-        """Create and place menu buttons"""
-        button = SubmenuButton(self, text=button_text, command=button_command)
+    def add_button(self, button_text: str, button_command: Callable) -> None:
+        """Create and place menu button"""
+        button = ContextMenuButton(self, text=button_text, command=button_command)
+        button.pack(expand=True, fill="both")
+
+    def add_submenu_button(self, button_text: str) -> SubmenuButton:
+        """Create and place submenu button"""
+        button = SubmenuButton(self, text=button_text, command=None)
         button.pack(expand=True, fill="both")
         return button
 
@@ -356,15 +357,19 @@ class _ContextMenuSubframe(CTkFrame):
             return ".!slickcontextmenu2" in ".!slickcontextmenu2.!_contextmenusubframe
             .!contextmenubutton"
         """
-        
+
         hovered_widget: str = self.get_widget_at_mouse().winfo_parent()
         return submenu.winfo_name() in hovered_widget
 
-    def get_widget_at_mouse(self) :
+    def get_widget_at_mouse(self) -> tk.Misc:
         """Get the mouse's x and y position and find the widget in that position"""
         x, y = self.winfo_pointerxy()
         widget = self.winfo_containing(x, y)
-        return widget
+
+        if widget is not None:
+            return widget
+        else:
+            return self
 
 
 if __name__ == "__main__":

--- a/src/SlickCTk/slick_frames.py
+++ b/src/SlickCTk/slick_frames.py
@@ -1,5 +1,5 @@
 from customtkinter import CTkFrame
-from slick_settings import COLOR_OUTLINES, FRAME_BORDER_WIDTH
+from SlickCTk.slick_settings import COLOR_OUTLINES, FRAME_BORDER_WIDTH
 
 
 class SlickFrame(CTkFrame):
@@ -59,7 +59,7 @@ class SlickFrameOutlined(SlickFrame):
 
 if __name__ == "__main__":
     import customtkinter as ctk
-    from slick_searchbar import SlickSearchbar
+    from SlickCTk.slick_searchbar import SlickSearchbar
 
     app = ctk.CTk()
     app.title("SlickFrame Demo")

--- a/src/SlickCTk/slick_searchbar.py
+++ b/src/SlickCTk/slick_searchbar.py
@@ -13,8 +13,8 @@ TODO:
 
 from tkinter import Canvas, font
 from customtkinter import CTkEntry, StringVar
-from utilities.dpi_scaler import DPIScaler
-from slick_settings import (
+from SlickCTk.utilities.dpi_scaler import DPIScaler
+from SlickCTk.slick_settings import (
     COLOR_APP_BACKGROUND,
     COLOR_TEXT,
     SEARCHBAR_COLOR_OUTLINE,
@@ -187,7 +187,7 @@ class _XButtonCanvas(Canvas):
 
 if __name__ == "__main__":
     import customtkinter as ctk
-    from slick_frames import SlickFrame
+    from SlickCTk.slick_frames import SlickFrame
 
     app = ctk.CTk()
     app.title("SlickSearchbar Demo")

--- a/src/SlickCTk/slick_settings.py
+++ b/src/SlickCTk/slick_settings.py
@@ -1,7 +1,6 @@
-# pylint: disable=missing-class-docstring, missing-function-docstring
-# pylint: disable=missing-module-docstring, 
+# pylint: disable=missing-module-docstring,
 
-from utilities.digsby.load_custom_font import load_font
+from SlickCTk.utilities.digsby.load_custom_font import load_font
 
 load_font("./src/SlickCTk/resources/fonts/Nunito-Bold.ttf")
 

--- a/src/SlickCTk/slick_treeview.py
+++ b/src/SlickCTk/slick_treeview.py
@@ -1,9 +1,8 @@
 # pylint: disable=missing-class-docstring, missing-function-docstring
 # pylint: disable=missing-module-docstring,
 
-
 from tkinter.ttk import Treeview, Style
-from slick_settings import (
+from SlickCTk.slick_settings import (
     TREEVIEW_COLOR_HEADING,
     TREEVIEW_COLOR_TEXT,
     TREEVIEW_COLOR_ROW_SELECTED,
@@ -115,7 +114,7 @@ class SlickStyleTreeview(Style):
 
 if __name__ == "__main__":
     import customtkinter as ctk
-    from slick_frames import SlickFrameOutlined
+    from SlickCTk.slick_frames import SlickFrameOutlined
 
     app = ctk.CTk()
     app.title("SlickTreeview Demo")


### PR DESCRIPTION
- Fix SlickCTk imports for package/src format; allows local editable install with `pip install -e .`

- Strict type checking implemented, which indicated conflicts with the .add_command() returning either ContextMenuButton or SubmenuButton; I split the function in two so normal menu buttons and submenu buttons are handled in their own funcs.